### PR TITLE
fix: remove invalid server id condition

### DIFF
--- a/packages/create-chooks-bot/src/bin/index.ts
+++ b/packages/create-chooks-bot/src/bin/index.ts
@@ -99,7 +99,7 @@ const response: Result = await prompts([
     name: 'server',
     message: kleur.green('Dev Discord Server ID:'),
     type: 'text',
-    validate: (id: string) => id.length === 18 && !Number.isNaN(id) || 'Invalid Server ID!',
+    validate: (id: string) => !Number.isNaN(id) || 'Invalid Server ID!',
   },
   {
     name: 'manager',


### PR DESCRIPTION
This PR removes the 18-digit condition for Server IDs since not all IDs are 18 digits. All recent servers are 19 digits and I believe some older ones might be 17 digits. Checking just for being a number should be enough.
Untested but I don't see how this change might break anything.